### PR TITLE
Revert "Update Helm release tenant to v5.0.7 (#54)"

### DIFF
--- a/argocd/applications/minio-tenant.yaml
+++ b/argocd/applications/minio-tenant.yaml
@@ -13,7 +13,7 @@ spec:
   sources:
     - chart: tenant
       repoURL: 'https://operator.min.io/'
-      targetRevision: 5.0.7
+      targetRevision: 5.0.6
       helm:
         valueFiles:
         - $values/minio/tenant-values.yaml


### PR DESCRIPTION
This reverts commit 774ddd3d525009d550f7e9c36f2051d528f86255.