### PR TITLE
Enable OTEL Kube Metrics

### DIFF
--- a/csi-driver-nfs/values.yaml
+++ b/csi-driver-nfs/values.yaml
@@ -7,6 +7,10 @@ controller:
           - matchExpressions:
               - key: node-role.kubernetes.io/system
                 operator: Exists
+  tolerations:
+    - key: "node-role.kubernetes.io/system"
+      operator: "Exists"
+      effect: "NoSchedule"
 
 node:
   tolerations:

--- a/opentelemetry-kube-stack/values.yaml
+++ b/opentelemetry-kube-stack/values.yaml
@@ -24,6 +24,20 @@ defaultCRConfig:
 
 collectors:
   daemon:
+    scrape_configs_file: "examples/prometheus-otel/kubelet_scrape_configs.yaml"
+    presets:
+      logsCollection:
+        enabled: false
+      kubeletMetrics:
+        enabled: false
+      hostMetrics:
+        enabled: false
+      kubernetesAttributes:
+        enabled: false
+      kubernetesEvents:
+        enabled: false
+      clusterMetrics:
+        enabled: false
     targetAllocator:
       enabled: true
       allocationStrategy: per-node
@@ -67,3 +81,28 @@ collectors:
           logs:
             exporters:
               - otlphttp/loki
+
+instrumentation:
+  enabled: false
+opAMPBridge:
+  enabled: false
+kubernetesServiceMonitors:
+  enabled: true
+kubeApiServer:
+  enabled: true
+kubelet:
+  enabled: true
+kubeControllerManager:
+  enabled: true
+kubeDns:
+  enabled: true
+kubeEtcd:
+  enabled: true
+kubeScheduler:
+  enabled: true
+kubeProxy:
+  enabled: true
+kubeStateMetrics:
+  enabled: true
+nodeExporter:
+  enabled: true


### PR DESCRIPTION
- Add scrape_configs_file for kubelet
- Introduce presets for various metrics and logs collection
- Enable key Kubernetes components and metrics exporters
- Set instrumentation and opAMPBridge to disabled