### PR TITLE
Update OpenTelemetry Kube Stack configuration in values.yaml

### DIFF
--- a/immich/immich-values.yaml
+++ b/immich/immich-values.yaml
@@ -23,6 +23,8 @@ env:
         key: password
   - name: IMMICH_MACHINE_LEARNING_URL
     value: "http://immich-immich-machine-learning:3003"
+  - name: IMMICH_TELEMETRY_INCLUDE
+    value: "all"
 
 immich:
   metrics:

--- a/opentelemetry-kube-stack/values.yaml
+++ b/opentelemetry-kube-stack/values.yaml
@@ -24,16 +24,16 @@ defaultCRConfig:
 
 collectors:
   daemon:
-    scrape_configs_file: "examples/prometheus-otel/kubelet_scrape_configs.yaml"
+    # scrape_configs_file: "examples/prometheus-otel/kubelet_scrape_configs.yaml"
     presets:
       logsCollection:
         enabled: false
       kubeletMetrics:
-        enabled: false
+        enabled: true
       hostMetrics:
         enabled: false
       kubernetesAttributes:
-        enabled: false
+        enabled: true
       kubernetesEvents:
         enabled: false
       clusterMetrics:
@@ -93,7 +93,7 @@ kubernetesServiceMonitors:
 kubeApiServer:
   enabled: true
 kubelet:
-  enabled: true
+  enabled: false
 kubeControllerManager:
   enabled: true
   serviceMonitor:


### PR DESCRIPTION
- Comment out the kubelet scrape_configs_file for clarity.
- Enable kubeletMetrics and kubernetesAttributes presets.
- Disable kubelet component to streamline resource usage.