### PR TITLE
Update OpenTelemetry Kube Stack configuration in values.yaml

### DIFF
--- a/opentelemetry-kube-stack/values.yaml
+++ b/opentelemetry-kube-stack/values.yaml
@@ -24,16 +24,16 @@ defaultCRConfig:
 
 collectors:
   daemon:
-    # scrape_configs_file: "examples/prometheus-otel/kubelet_scrape_configs.yaml"
+    scrape_configs_file: ""
     presets:
       logsCollection:
         enabled: false
       kubeletMetrics:
-        enabled: true
+        enabled: false 
       hostMetrics:
         enabled: false
       kubernetesAttributes:
-        enabled: true
+        enabled: false 
       kubernetesEvents:
         enabled: false
       clusterMetrics:
@@ -55,6 +55,234 @@ collectors:
           operator: "Exists"
           effect: "NoSchedule"
     config:
+      receivers:
+        prometheus:
+          config:
+            scrape_configs:
+              - authorization:
+                  credentials_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+                  type: Bearer
+                follow_redirects: true
+                honor_labels: true
+                honor_timestamps: true
+                job_name: kubelet
+                kubernetes_sd_configs:
+                - follow_redirects: true
+                  kubeconfig_file: ''
+                  role: node
+                metrics_path: "/metrics"
+                relabel_configs:
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - job
+                  target_label: __tmp_prometheus_job_name
+                - action: replace
+                  replacement: "kubelet"
+                  target_label: job
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __meta_kubernetes_node_name
+                  target_label: node
+                - action: replace
+                  regex: "(.*)"
+                  replacement: https-metrics
+                  separator: ";"
+                  target_label: endpoint
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __metrics_path__
+                  target_label: metrics_path
+                - action: hashmod
+                  modulus: 1
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __address__
+                  target_label: __tmp_hash
+                - action: keep
+                  regex: "$(SHARD)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __tmp_hash
+                scheme: https
+                scrape_interval: 30s
+                scrape_timeout: 10s
+                tls_config:
+                  ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                  insecure_skip_verify: true
+              - authorization:
+                  credentials_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+                  type: Bearer
+                follow_redirects: true
+                honor_labels: true
+                honor_timestamps: true
+                job_name: serviceMonitor/opentelemetry-operator-system/opentelemetry-kube-stack-kubelet/1
+                kubernetes_sd_configs:
+                - follow_redirects: true
+                  kubeconfig_file: ''
+                  role: node
+                metric_relabel_configs:
+                - action: drop
+                  regex: container_cpu_(cfs_throttled_seconds_total|load_average_10s|system_seconds_total|user_seconds_total)
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __name__
+                - action: drop
+                  regex: container_fs_(io_current|io_time_seconds_total|io_time_weighted_seconds_total|reads_merged_total|sector_reads_total|sector_writes_total|writes_merged_total)
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __name__
+                - action: drop
+                  regex: container_memory_(mapped_file|swap)
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __name__
+                - action: drop
+                  regex: container_(file_descriptors|tasks_state|threads_max)
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __name__
+                - action: drop
+                  regex: container_spec.*
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __name__
+                - action: drop
+                  regex: ".+;"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - id
+                  - pod
+                metrics_path: "/metrics/cadvisor"
+                relabel_configs:
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - job
+                  target_label: __tmp_prometheus_job_name
+                - action: replace
+                  replacement: "kubelet"
+                  target_label: job
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __meta_kubernetes_node_name
+                  target_label: node
+                - action: replace
+                  regex: "(.*)"
+                  replacement: https-metrics
+                  separator: ";"
+                  target_label: endpoint
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __metrics_path__
+                  target_label: metrics_path
+                - action: hashmod
+                  modulus: 1
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __address__
+                  target_label: __tmp_hash
+                - action: keep
+                  regex: "$(SHARD)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __tmp_hash
+                scheme: https
+                scrape_interval: {{ .kubelet.serviceMonitor.scrapeTimeout | default "30s" }}
+                scrape_timeout: 10s
+                tls_config:
+                  ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                  insecure_skip_verify: true
+              - authorization:
+                  credentials_file: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+                  type: Bearer
+                follow_redirects: true
+                honor_labels: true
+                honor_timestamps: true
+                job_name: serviceMonitor/opentelemetry-operator-system/opentelemetry-kube-stack-kubelet/2
+                kubernetes_sd_configs:
+                - follow_redirects: true
+                  kubeconfig_file: ''
+                  role: node
+                metrics_path: "/metrics/probes"
+                relabel_configs:
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - job
+                  target_label: __tmp_prometheus_job_name
+                - action: replace
+                  replacement: "kubelet"
+                  target_label: job
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __meta_kubernetes_node_name
+                  target_label: node
+                - action: replace
+                  regex: "(.*)"
+                  replacement: https-metrics
+                  separator: ";"
+                  target_label: endpoint
+                - action: replace
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __metrics_path__
+                  target_label: metrics_path
+                - action: hashmod
+                  modulus: 1
+                  regex: "(.*)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __address__
+                  target_label: __tmp_hash
+                - action: keep
+                  regex: "$(SHARD)"
+                  replacement: "$$1"
+                  separator: ";"
+                  source_labels:
+                  - __tmp_hash
+                scheme: https
+                scrape_interval: 30s
+                scrape_timeout: 10s
+                tls_config:
+                  ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                  insecure_skip_verify: true
       exporters:
         otlp/tempo:
           endpoint: lgtm-tempo-gateway.monitoring.svc.cluster.local:4317
@@ -93,7 +321,7 @@ kubernetesServiceMonitors:
 kubeApiServer:
   enabled: true
 kubelet:
-  enabled: false
+  enabled: true
 kubeControllerManager:
   enabled: true
   serviceMonitor:


### PR DESCRIPTION
- Disable kubeletMetrics and kubernetesAttributes presets to streamline resource usage.
- Enable kubelet component for improved metrics collection.
- Add detailed Prometheus scrape configurations for kubelet and service monitors, enhancing observability and metrics collection capabilities.