### PR TITLE
Update scrape_interval in OpenTelemetry Kube Stack configuration (#1152)

### DIFF
--- a/opentelemetry-kube-stack/values.yaml
+++ b/opentelemetry-kube-stack/values.yaml
@@ -216,7 +216,7 @@ collectors:
                   source_labels:
                   - __tmp_hash
                 scheme: https
-                scrape_interval: {{ .kubelet.serviceMonitor.scrapeTimeout | default "30s" }}
+                scrape_interval: 30s
                 scrape_timeout: 10s
                 tls_config:
                   ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"


### PR DESCRIPTION
- Set the kubelet service monitor's scrape_interval to a fixed value of 30s for consistency and clarity in metrics collection.