### PR TITLE
Update MinIO tenant configuration to unify naming conventions

### DIFF
--- a/minio/ingress/minio-tenant-cold-tier/minio-tenant-cold-tier-console.yaml
+++ b/minio/ingress/minio-tenant-cold-tier/minio-tenant-cold-tier-console.yaml
@@ -11,7 +11,7 @@ spec:
   http:
   - route:
     - destination:
-        host: minio-console-cold-tier
+        host: minio-console
         port:
           number: 9443
 ---
@@ -21,7 +21,7 @@ metadata:
   name: minio-tenant-cold-tier-console-dr
   namespace: minio-cold-tier
 spec:
-  host: minio-console-cold-tier
+  host: minio-console
   trafficPolicy:
     tls:
       mode: SIMPLE

--- a/minio/ingress/minio-tenant-cold-tier/minio-tenant-cold-tier-s3.yaml
+++ b/minio/ingress/minio-tenant-cold-tier/minio-tenant-cold-tier-s3.yaml
@@ -11,7 +11,7 @@ spec:
   http:
   - route:
     - destination:
-        host: minio-cold-tier
+        host: minio
         port:
           number: 443
 ---
@@ -21,7 +21,7 @@ metadata:
   name: minio-tenant-cold-tier-s3-dr
   namespace: minio-cold-tier
 spec:
-  host: minio-cold-tier
+  host: minio
   trafficPolicy:
     tls:
       mode: SIMPLE

--- a/minio/tenant-cold-tier-values.yaml
+++ b/minio/tenant-cold-tier-values.yaml
@@ -1,5 +1,5 @@
 tenant:
-  name: minio-cold-tier
+  name: minio
   pools:
     - servers: 4
       name: pool-0


### PR DESCRIPTION
- Changed tenant name from 'minio-cold-tier' to 'minio' in tenant-cold-tier-values.yaml.
- Updated ingress configurations for console and S3 access to reflect the new host name 'minio' instead of 'minio-cold-tier' in respective YAML files.