### PR TITLE
Feature/minio-cold-tier

### DIFF
--- a/minio/argocd/minio-tenant-cold-tier-monitor.yaml
+++ b/minio/argocd/minio-tenant-cold-tier-monitor.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "40"
+  name: minio-tenant-cold-tier-monitor
+  namespace: argocd
+spec:
+  project: default
+  destination:
+    namespace: minio
+    server: 'https://kubernetes.default.svc'
+  sources:
+    - repoURL: 'https://github.com/XuhuiSun95/homelab-k8s.git'
+      targetRevision: main
+      path: minio/monitors/minio-tenant-cold-tier
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true

--- a/minio/monitors/minio-tenant-cold-tier/tenant-service-monitor.yaml
+++ b/minio/monitors/minio-tenant-cold-tier/tenant-service-monitor.yaml
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: minio-cluster
+  namespace: minio-cold-tier
+spec:
+  selector:
+    matchLabels:
+      app: minio
+  namespaceSelector:
+    matchNames:
+      - minio-cold-tier
+  endpoints:
+  - port: https-minio
+    path: /minio/v2/metrics/cluster
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: minio-bucket
+  namespace: minio-cold-tier
+spec:
+  selector:
+    matchLabels:
+      app: minio
+  namespaceSelector:
+    matchNames:
+      - minio-cold-tier
+  endpoints:
+  - port: https-minio
+    path: /minio/v2/metrics/bucket
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true

--- a/minio/tenant-cold-tier-values.yaml
+++ b/minio/tenant-cold-tier-values.yaml
@@ -1,10 +1,10 @@
 tenant:
   name: minio
   pools:
-    - servers: 1
+    - servers: 4
       name: pool-0
-      volumesPerServer: 1
-      size: 1Ti
+      volumesPerServer: 4
+      size: 100Gi
       storageClassName: nfs-csi
       resources:
         requests:
@@ -26,9 +26,14 @@ tenant:
   buckets:
     - name: "cold-tier"
   # prometheusOperator: true
+  serviceMetadata:
+    minioServiceLabels:
+      app: minio
   env:
     # - name: MINIO_PROMETHEUS_URL
     #   value: "http://lgtm-distributed-mimir-nginx.monitoring.svc.cluster.local/prometheus"
+    - name: MINIO_PROMETHEUS_AUTH_TYPE
+      value: "public"
     - name: MINIO_IDENTITY_OPENID_CONFIG_URL_KEYCLOAK_PRIMARY
       value: "https://iam.local-v2.xuhuisun.com/realms/local-v2/.well-known/openid-configuration"
     - name: MINIO_IDENTITY_OPENID_CLIENT_ID_KEYCLOAK_PRIMARY


### PR DESCRIPTION
- Increased server count from 1 to 4 and adjusted volumes per server from 1 to 4.
- Changed storage size from 1Ti to 100Gi for improved capacity.
- Added service metadata with MinIO service labels and updated environment variables for Prometheus authentication.