### PR TITLE
Add TLS configuration for kubeApiServer in values.yaml

### DIFF
--- a/opentelemetry-kube-stack/values.yaml
+++ b/opentelemetry-kube-stack/values.yaml
@@ -320,6 +320,8 @@ kubernetesServiceMonitors:
   enabled: true
 kubeApiServer:
   enabled: true
+  tlsConfig:
+    insecureSkipVerify: true
 kubelet:
   enabled: true
 kubeControllerManager:


### PR DESCRIPTION
- Enabled TLS with insecureSkipVerify set to true for the kubeApiServer to enhance security settings in the OpenTelemetry Kube Stack configuration.