### PR TITLE
Update Grafana Keycloak configuration URLs to use internal service endpoints

### DIFF
--- a/keycloak/ingress/keycloak.yaml
+++ b/keycloak/ingress/keycloak.yaml
@@ -22,10 +22,6 @@ spec:
     - authority:
         exact: iam.local.xuhuisun.com
       uri:
-        exact: /
-    - authority:
-        exact: iam.local.xuhuisun.com
-      uri:
         prefix: /realms/
     - authority:
         exact: iam.local.xuhuisun.com
@@ -52,6 +48,5 @@ spec:
     loadBalancer:
       consistentHash:
         httpCookie:
-          name: STICKY_SESSION
+          name: AUTH_SESSION_ID
           ttl: 0s
-          path: /

--- a/lgtm/grafana-values.yaml
+++ b/lgtm/grafana-values.yaml
@@ -185,12 +185,12 @@ grafana.ini:
     email_attribute_path: email
     login_attribute_path: username
     name_attribute_path: full_name
-    auth_url: https://iam.local.xuhuisun.com/realms/local/protocol/openid-connect/auth
-    token_url: https://iam.local.xuhuisun.com/realms/local/protocol/openid-connect/token
-    api_url: https://iam.local.xuhuisun.com/realms/local/protocol/openid-connect/userinfo
+    auth_url: http://keycloak-keycloak.keycloak.svc.cluster.local/realms/local/protocol/openid-connect/auth
+    token_url: http://keycloak-keycloak.keycloak.svc.cluster.local/realms/local/protocol/openid-connect/token
+    api_url: http://keycloak-keycloak.keycloak.svc.cluster.local/realms/local/protocol/openid-connect/userinfo
     role_attribute_path: "contains(resource_access.grafana.roles[*], 'grafanaadmin') && 'GrafanaAdmin' || contains(resource_access.grafana.roles[*], 'admin') && 'Admin' || contains(resource_access.grafana.roles[*], 'editor') && 'Editor' || 'Viewer'"
     groups_attribute_path: groups
-    signout_redirect_url: https://iam.local.xuhuisun.com/realms/local/protocol/openid-connect/logout?post_logout_redirect_uri=https%3A%2F%2Fgrafana.local.xuhuisun.com%2Flogin
+    signout_redirect_url: http://keycloak-keycloak.keycloak.svc.cluster.local/realms/local/protocol/openid-connect/logout?post_logout_redirect_uri=https%3A%2F%2Fgrafana.local.xuhuisun.com%2Flogin
     allow_assign_grafana_admin: true
     use_pkce: true
     use_refresh_token: true


### PR DESCRIPTION
- Changed authentication, token, API, and signout redirect URLs from external to internal Keycloak service endpoints for improved security and reliability.